### PR TITLE
CTL: Use GNUInstallDirs and fix PkgConfig files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,14 @@
 cmake_minimum_required(VERSION 2.8)
 project( CTL )
 
+INCLUDE ( GNUInstallDirs )
+
 set( CTL_MAJOR_VERSION 1 )
 set( CTL_MINOR_VERSION 5 )
-set( CTL_PATCH_VERSION 0 )
+set( CTL_PATCH_VERSION 2 )
 set( CTL_VERSION ${CTL_MAJOR_VERSION}.${CTL_MINOR_VERSION}.${CTL_PATCH_VERSION} )
 
-## Make install directories overrideable
-set( INSTALL_LIB_DIR lib CACHE PATH "Install directory for libraries" )
-set( INSTALL_BIN_DIR bin CACHE PATH "Install directory for executable binaries" )
-set( INSTALL_INCLUDE_DIR include CACHE PATH "Install directory for public header files" )
-set( INSTALL_DOC_DIR doc CACHE PATH "Install directory for documentation" )
-if( WIN32 AND NOT CYGWIN )
-  set(DEF_INSTALL_CMAKE_DIR CMake)
-else()
-  set(DEF_INSTALL_CMAKE_DIR lib/CMake/CTL)
-endif()
-set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Install directory for project CMake files" )
+set(INSTALL_CMAKE_DIR ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/CTL CACHE PATH "Install directory for project CMake files" )
 
 # use, i.e. don't skip the full RPATH for the build tree
 SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
@@ -28,19 +20,10 @@ SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 # which point to directories outside the build tree to the install RPATH
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 # the RPATH to be used when installing, but only if it's not a system directory
-LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_FULL_LIBDIR}" isSystemDir)
 IF("${isSystemDir}" STREQUAL "-1")
-  SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+  SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
 ENDIF("${isSystemDir}" STREQUAL "-1")
-
-
-## convert install paths to absolute
-foreach( p LIB BIN INCLUDE CMAKE DOC)
-  set( var INSTALL_${p}_DIR )
-  if( NOT IS_ABSOLUTE "${${var}}" )
-    set( ${var} "${CMAKE_INSTALL_PREFIX}/${${var}}" )
-  endif()
-endforeach()
 
 option(ENABLE_SHARED "Enable Shared Libraries" ON)
 
@@ -70,20 +53,19 @@ export( TARGETS IlmCtl IlmCtlMath IlmCtlSimd FILE "${PROJECT_BINARY_DIR}/CTLLibr
 export(PACKAGE CTL)
  
 # Create a CTLBuildTreeSettings.cmake file for the use from the build tree
-file(RELATIVE_PATH CONF_REL_INCLUDE_DIR "${INSTALL_CMAKE_DIR}" "${INSTALL_INCLUDE_DIR}")
+file(RELATIVE_PATH CONF_REL_INCLUDE_DIR "${INSTALL_CMAKE_DIR}" "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
 configure_file(config/CTLBuildTreeSettings.cmake.in "${PROJECT_BINARY_DIR}/CTLBuildTreeSettings.cmake" @ONLY)
 configure_file(config/CTLConfig.cmake.in "${PROJECT_BINARY_DIR}/CTLConfig.cmake" @ONLY)
 configure_file(config/CTLConfigVersion.cmake.in "${PROJECT_BINARY_DIR}/CTLConfigVersion.cmake" @ONLY)
 
 if ( PKG_CONFIG_FOUND )
 configure_file(config/CTL.pc.in "${PROJECT_BINARY_DIR}/CTL.pc" @ONLY)
-install( FILES "${PROJECT_BINARY_DIR}/CTL.pc" DESTINATION lib/pkgconfig COMPONENT dev )
+install( FILES "${PROJECT_BINARY_DIR}/CTL.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT dev )
 endif()
 
 install( FILES
   "${PROJECT_BINARY_DIR}/CTLConfig.cmake"
   "${PROJECT_BINARY_DIR}/CTLConfigVersion.cmake"
+  "${PROJECT_BINARY_DIR}/CTLLibraryDepends.cmake"
   DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
-install(FILES "${PROJECT_BINARY_DIR}/CTLLibraryDepends.cmake" DESTINATION
-  "${INSTALL_CMAKE_DIR}" COMPONENT dev)
 

--- a/OpenEXR_CTL/CMakeLists.txt
+++ b/OpenEXR_CTL/CMakeLists.txt
@@ -13,7 +13,7 @@ add_custom_target( OpenEXR_CTL DEPENDS CtlModules exrdpx exr_ctl_exr )
 
 if ( PKG_CONFIG_FOUND )
 configure_file(../config/OpenEXR_CTL.pc.in "${PROJECT_BINARY_DIR}/OpenEXR_CTL.pc" @ONLY)
-install( FILES "${PROJECT_BINARY_DIR}/OpenEXR_CTL.pc" DESTINATION lib/pkgconfig COMPONENT dev )
+install( FILES "${PROJECT_BINARY_DIR}/OpenEXR_CTL.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT dev )
 endif()
 
 # TODO CMake config

--- a/OpenEXR_CTL/CtlModules/CMakeLists.txt
+++ b/OpenEXR_CTL/CtlModules/CMakeLists.txt
@@ -2,6 +2,6 @@ install(
     FILES
         utilities.ctl
     DESTINATION 
-        ${INSTALL_LIB_DIR}/CTL
+        ${CMAKE_INSTALL_LIBDIR}/CTL
 )
 

--- a/OpenEXR_CTL/exr_ctl_exr/CMakeLists.txt
+++ b/OpenEXR_CTL/exr_ctl_exr/CMakeLists.txt
@@ -20,6 +20,6 @@ target_link_libraries( exr_ctl_exr IlmCtlSimd IlmCtlMath IlmCtl IlmImfCtl )
 target_link_libraries( exr_ctl_exr ${IlmBase_LIBRARIES} ${IlmBase_LDFLAGS_OTHER} )
 target_link_libraries( exr_ctl_exr ${OpenEXR_LIBRARIES} ${OpenEXR_LDFLAGS_OTHER} )
 
-install( TARGETS exr_ctl_exr DESTINATION ${INSTALL_BIN_DIR} )
+install( TARGETS exr_ctl_exr DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
-install( FILES change_saturation.ctl DESTINATION ${INSTALL_LIB_DIR}/CTL )
+install( FILES change_saturation.ctl DESTINATION ${CMAKE_INSTALL_LIBDIR}/CTL )

--- a/OpenEXR_CTL/exrdpx/CMakeLists.txt
+++ b/OpenEXR_CTL/exrdpx/CMakeLists.txt
@@ -20,8 +20,8 @@ target_link_libraries( exrdpx IlmCtlSimd IlmCtlMath IlmCtl IlmImfCtl )
 target_link_libraries( exrdpx ${IlmBase_LIBRARIES} ${IlmBase_LDFLAGS_OTHER} )
 target_link_libraries( exrdpx ${OpenEXR_LIBRARIES} ${OpenEXR_LDFLAGS_OTHER} )
 
-install( TARGETS exrdpx DESTINATION ${INSTALL_BIN_DIR} )
+install( TARGETS exrdpx DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
-install( FILES transform_DPX_EXR.ctl transform_EXR_DPX.ctl DESTINATION ${INSTALL_LIB_DIR}/CTL )
+install( FILES transform_DPX_EXR.ctl transform_EXR_DPX.ctl DESTINATION ${CMAKE_INSTALL_LIBDIR}/CTL )
 
 

--- a/config/CTL.pc.in
+++ b/config/CTL.pc.in
@@ -1,11 +1,10 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@INSTALL_BIN_DIR@
-libdir=@INSTALL_LIB_DIR@
-includedir=@INSTALL_INCLUDE_DIR@
-CTL_includedir=@INSTALL_INCLUDE_DIR@/CTL
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+CTL_includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/CTL
 
 Name: CTL
 Description: CTL interpreter library
 Version: @CTL_VERSION@
-Libs: -L${libdir} -lIlmCtlSimd -lIlmCtlMath -lIlmCtl @IlmBase_LDFLAGS@
-Cflags: @IlmBase_CFLAGS@ -I${CTL_includedir}
+Libs: -L${libdir} -lIlmCtlSimd -lIlmCtlMath -lIlmCtl
+Cflags: -I${CTL_includedir}
+Requires: IlmBase

--- a/config/OpenEXR_CTL.pc.in
+++ b/config/OpenEXR_CTL.pc.in
@@ -1,11 +1,10 @@
-prefix=@prefix@
-exec_prefix=@exec_prefix@
-libdir=@libdir@
-includedir=@includedir@
-OpenEXR_includedir=@includedir@/OpenEXR
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+OpenEXR_includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/OpenEXR
 
 Name: OpenEXR_CTL
 Description: Simplified OpenEXR interface to CTL
-Version: @OPENEXR_CTL_VERSION@
-Libs: -L${libdir} -lIlmImfCtl @OPENEXR_LDFLAGS@ @CTL_LDFLAGS@
-Cflags: @CTL_CXXFLAGS_PC@ @OPENEXR_CXXFLAGS@ -I${OpenEXR_includedir}
+Version: @CTL_VERSION@
+Libs: -L${libdir} -lIlmImfCtl
+Cflags: -I${OpenEXR_includedir}
+Requires: CTL,OpenEXR

--- a/configure.cmake
+++ b/configure.cmake
@@ -1,10 +1,7 @@
-# Until we get some of these modules into the upstream packages, put them here
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_INSTALL_PREFIX}/share/CMake")
+# Make Pkg-Config required.
+find_package( PkgConfig )
 
-find_package( PkgConfig QUIET )
-
-find_package( IlmBase QUIET )
+PKG_CHECK_MODULES ( IlmBase REQUIRED IlmBase )
 if(IlmBase_FOUND)
   message( STATUS "found IlmBase, version ${IlmBase_VERSION}" )
   ###
@@ -13,11 +10,11 @@ if(IlmBase_FOUND)
   ###
   include_directories( ${IlmBase_INCLUDE_DIRS} )
   link_directories( ${IlmBase_LIBRARY_DIRS} )
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${IlmBase_CFLAGS}" )
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IlmBase_CFLAGS}" )
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${IlmBase_LDFLAGS}" )
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${IlmBase_LDFLAGS}" )
-  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${IlmBase_LDFLAGS}" )
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${IlmBase_CFLAGS_OTHER}" )
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IlmBase_CFLAGS_OTHER}" )
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${IlmBase_LDFLAGS_OTHER}" )
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${IlmBase_LDFLAGS_OTHER}" )
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${IlmBase_LDFLAGS_OTHER}" )
 else()
   message( SEND_ERROR "IlmBase not found, please set the include and library paths manually" )
 endif()
@@ -39,7 +36,7 @@ else()
   endif()
 endif()
 
-find_package( OpenEXR QUIET )
+PKG_CHECK_MODULES ( OpenEXR REQUIRED OpenEXR )
 if (OpenEXR_FOUND)
   message( STATUS "Found OpenEXR, version ${OpenEXR_VERSION}" )
 else()

--- a/ctlrender/CMakeLists.txt
+++ b/ctlrender/CMakeLists.txt
@@ -16,7 +16,7 @@ add_definitions( -DHAVE_ACESFILE=1 )
 include_directories( ${AcesContainer_INCLUDE_DIRS} )
 link_directories( ${AcesContainer_LIBRARY_DIRS} )
 endif()
-
+ 
 include_directories( "${CMAKE_CURRENT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/lib/IlmCtl" "${PROJECT_SOURCE_DIR}/lib/IlmCtlMath" "${PROJECT_SOURCE_DIR}/lib/IlmCtlSimd" "${PROJECT_SOURCE_DIR}/lib/dpx" )
 
 add_executable( ctlrender
@@ -46,4 +46,4 @@ target_link_libraries( ctlrender ${AcesContainer_LIBRARIES} )
 target_link_libraries( ctlrender ${AcesContainer_LDFLAGS_OTHER} )
 endif()
 
-install( TARGETS ctlrender DESTINATION bin )
+install( TARGETS ctlrender DESTINATION ${CMAKE_INSTALL_BINDIR} )

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,1 +1,1 @@
-install( FILES CtlManual.pdf CtlManual.doc DESTINATION doc/CTL )
+install( FILES CtlManual.pdf CtlManual.doc DESTINATION ${CMAKE_INSTALL_DOCDIR} )

--- a/lib/IlmCtl/CMakeLists.txt
+++ b/lib/IlmCtl/CMakeLists.txt
@@ -22,7 +22,7 @@ add_library( IlmCtl ${DO_SHARED}
 )
 
 target_link_libraries( IlmCtl ${IlmBase_LDFLAGS_OTHER} )
-target_link_libraries( IlmCtl Iex IlmThread Half )
+target_link_libraries( IlmCtl ${IlmBase_LIBRARIES} )
 
 set_target_properties( IlmCtl PROPERTIES
   VERSION ${CTL_VERSION}
@@ -50,4 +50,4 @@ install( FILES
 	CtlVersion.h
  DESTINATION include/CTL )
 
-install( TARGETS IlmCtl DESTINATION lib )
+install( TARGETS IlmCtl DESTINATION ${CMAKE_INSTALL_LIBDIR} )

--- a/lib/IlmCtlMath/CMakeLists.txt
+++ b/lib/IlmCtlMath/CMakeLists.txt
@@ -18,8 +18,8 @@ install( FILES
   CtlLookupTable.h
   CtlRbfInterpolator.h
   CtlSparseMatrix.h
- DESTINATION include/CTL )
+ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/CTL )
 
-install( TARGETS IlmCtlMath DESTINATION lib )
+install( TARGETS IlmCtlMath DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 
 # TODO Add Imath and Iex libadd dependency and version info

--- a/lib/IlmCtlSimd/CMakeLists.txt
+++ b/lib/IlmCtlSimd/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories( "${CMAKE_CURRENT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/lib/IlmCtl" "${PROJECT_SOURCE_DIR}/lib/IlmCtlMath" )
 
 add_executable( halfExpLogTable halfExpLogTable.cpp )
-target_link_libraries( halfExpLogTable Half )
+target_link_libraries( halfExpLogTable ${IlmBase_LIBRARIES} )
 
 add_custom_command( OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/halfExpLogTable.h"
                     COMMAND halfExpLogTable "${CMAKE_CURRENT_BINARY_DIR}/halfExpLogTable.h" "${CMAKE_CURRENT_BINARY_DIR}/halfExpLog.h"
@@ -40,6 +40,6 @@ set_target_properties( IlmCtlSimd PROPERTIES
   SOVERSION ${CTL_VERSION}
 )
 
-install( FILES CtlSimdInterpreter.h DESTINATION include/CTL )
+install( FILES CtlSimdInterpreter.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/CTL )
 
-install( TARGETS IlmCtlSimd DESTINATION lib )
+install( TARGETS IlmCtlSimd DESTINATION ${CMAKE_INSTALL_LIBDIR} )

--- a/lib/IlmImfCtl/CMakeLists.txt
+++ b/lib/IlmImfCtl/CMakeLists.txt
@@ -7,10 +7,10 @@ add_library( IlmImfCtl ${DO_SHARED}
   ImfCtlCopyFunctionArg.cpp
 )
 
-target_link_libraries( IlmImfCtl IlmCtl IlmImf Iex IlmThread Half )
+target_link_libraries( IlmImfCtl IlmCtl ${OpenEXR_LIBRARIES} ${IlmBase_LIBRARIES} )
 
-install( FILES ImfCtlApplyTransforms.h DESTINATION include/OpenEXR )
+install( FILES ImfCtlApplyTransforms.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OpenEXR )
 
 export( TARGETS IlmImfCtl IlmCtl FILE "${PROJECT_BINARY_DIR}/CTLLibraryDepends.cmake" )
 
-install( TARGETS IlmImfCtl DESTINATION lib )
+install( TARGETS IlmImfCtl DESTINATION ${CMAKE_INSTALL_LIBDIR} )

--- a/lib/dpx/CMakeLists.txt
+++ b/lib/dpx/CMakeLists.txt
@@ -11,3 +11,4 @@ add_library( ctldpx
  dpx_rw.cc
 )
 
+target_link_libraries( ctldpx ${IlmBase_LIBRARIES} )


### PR DESCRIPTION
* GNUInstallDirs are variables set by each distro and OS, so we
  don't need to define them manually. They can also be set manually
  during the configure phase. The code to define custom directories can
  be removed and replaced with the equivalent GNUInstallDirs variable.
* Pkg-Config is used to find IlmBase and OpenEXR, but isn't fully
  utilized everywhere. This makes Pkg-Config a hard dependency so that
  the libraries and directories can be found easily. This will use the
  correct libraries no matter how they are named, so this is compatible
  with both pre-2.0 and post 2.0 naming schemes.
* The Pkg-Config files had several errors that are now fixed.